### PR TITLE
Reset DB

### DIFF
--- a/lib/proc/database.js
+++ b/lib/proc/database.js
@@ -21,6 +21,7 @@ goog.require('lf.Exception');
 goog.require('lf.base');
 goog.require('lf.proc.ExportTask');
 goog.require('lf.proc.ImportTask');
+goog.require('lf.proc.ResetTask');
 goog.require('lf.proc.Transaction');
 goog.require('lf.query.DeleteBuilder');
 goog.require('lf.query.InsertBuilder');
@@ -166,6 +167,17 @@ lf.proc.Database.prototype.export = function() {
   var task = new lf.proc.ExportTask(this.global_);
   return this.runner_.scheduleTask(task).then(function(results) {
     return results[0].getPayloads()[0];
+  });
+};
+
+/**
+ * @param {!lf.schema.ConnectOptions=} opt_options
+ * @export
+ */
+lf.proc.Database.prototype.reset = function(opt_options) {
+  var task = new lf.proc.ResetTask(this.global_, this, opt_options);
+  return this.runner_.scheduleTask(task).then(function() {
+    return null;
   });
 };
 

--- a/lib/proc/reset_task.js
+++ b/lib/proc/reset_task.js
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2015 The Lovefield Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+goog.provide('lf.proc.ResetTask');
+
+goog.require('goog.Promise');
+goog.require('lf.TransactionType');
+goog.require('lf.cache.Prefetcher');
+goog.require('lf.proc.Task');
+goog.require('lf.proc.TaskPriority');
+goog.require('lf.service');
+goog.require('lf.structs.set');
+ 
+  
+/**
+ * Resets the Lovefield cache
+ * @implements {lf.proc.Task}
+ * @constructor
+ * @struct
+ *
+ * @param {!lf.Global} global
+ * @param {!lf.proc.Database} database
+ * @param {!lf.schema.ConnectOptions=} opt_options
+ */
+lf.proc.ResetTask = function(global, database, opt_options) {
+  /** @private {!lf.Global} */
+  this.global_ = global;
+
+  /** @private {!lf.proc.Database} */
+  this.database_ = database;
+
+  /** @private {?lf.schema.ConnectOptions} */
+  this.opt_options_ = opt_options || null;
+
+  /** @private {!lf.structs.Set<!lf.schema.Table>} */
+  this.scope_ = lf.structs.set.create(this.database_.getSchema().tables());
+
+  /** @private {!goog.promise.Resolver<!Array<!lf.proc.Relation>>} */
+  this.resolver_ = goog.Promise.withResolver();
+
+};
+
+
+/** @override */
+lf.proc.ResetTask.prototype.exec = function() {
+  if (!this.database_.isOpen()) {
+    return goog.Promise.resolve();
+  }
+  this.database_.close();
+
+  return this.database_.init(this.opt_options_ || undefined).then(
+    function(db) {
+      return db;
+    }.bind(this),
+    function(e) {
+      this.database_.close();
+      throw e;
+    }.bind(this));
+};
+
+
+/** @override */
+lf.proc.ResetTask.prototype.getType = function() {
+  return lf.TransactionType.READ_WRITE;
+};
+
+
+/** @override */
+lf.proc.ResetTask.prototype.getScope = function() {
+  return this.scope_;
+};
+
+
+/** @override */
+lf.proc.ResetTask.prototype.getResolver = function() {
+  return this.resolver_;
+};
+
+
+/** @override */
+lf.proc.ResetTask.prototype.getId = function() {
+  return goog.getUid(this);
+};
+
+
+/** @override */
+lf.proc.ResetTask.prototype.getPriority = function() {
+  return lf.proc.TaskPriority.RESET_TASK;
+};

--- a/lib/proc/task.js
+++ b/lib/proc/task.js
@@ -73,6 +73,7 @@ lf.proc.Task.prototype.getPriority;
 lf.proc.TaskPriority = {
   EXPORT_TASK: 0,
   IMPORT_TASK: 0,
+  RESET_TASK: 0,
   OBSERVER_QUERY_TASK: 0,
   EXTERNAL_CHANGE_TASK: 1,
   USER_QUERY_TASK: 2,


### PR DESCRIPTION
This is an alternative to https://github.com/dcSpark/lovefield/pull/1 that doesn't have to manually reset cache (instead just closes and re-opens the DB within a lock on the DB)

Unfortunately this PR doesn't work in its current state because a bunch of tasks use functions like `checkActive_` that read the DB state before acquiring their locks and so to get this PR working you would need to refactor a bunch of stuff